### PR TITLE
Use a slice instead of a map

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@
 ```bash
 # cat vault.yaml
 keys:
-  secret/integration/test:
-    bar: foo
-    foo: bar
+  - key: secret/integration/test
+    values:
+      bar: foo
+      foo: bar
 
 # yaml-vault --import -f vault.yaml
 


### PR DESCRIPTION
This enables the user to specify an order in which the writes will be executed. This can be used to first mount a backend and then write configuration to it. With a map this would not be possible because the order of a map is not deterministic.

**breaking-change**
